### PR TITLE
Appveyor integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tags*
 build/
 build-tests/
 target/
+
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ bchannel = "*"
 git = "https://github.com/meqif/rust-utp"
 
 [dependencies.sodiumoxide]
-git = "https://github.com/dnaq/sodiumoxide"
+git = "https://github.com/krishnaindia/sodiumoxide"
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Travis build and test status
 
 [Documentation](http://dirvine.github.io/routing)
 
+### Build Pre-requisite:
+libsodium is a native dependency for [sodiumxoide](https://github.com/dnaq/sodiumoxide). Thus, install sodium by following the instructions [here](http://doc.libsodium.org/installation/README.html).
+
+For windows, download and use the [prebuilt mingw library](https://download.libsodium.org/libsodium/releases/libsodium-1.0.2-mingw.tar.gz). 
+Extract and place the libsodium.a file in the "third_party_libs" folder in the Project Root.
+
 ##Todo Items
 
 - [x] Set up facade design pattern

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,16 @@ install:
   - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin
   - rustc --version
   - cargo --version
+  - cinst 7zip.commandline -x86
+  - ps: if($env:RUST_INSTALL_TRIPLE -eq 'x86_64-pc-windows-gnu') {
+         Start-FileDownload "http://libgd.blob.core.windows.net/mingw/mingw-w64-dgn-x86_64-20141001.7z";
+         7z x -oC:\ mingw-w64-dgn-x86_64-20141001.7z;
+       }
+  - ps: Start-FileDownload 'https://download.libsodium.org/libsodium/releases/libsodium-1.0.2-mingw.tar.gz'
+  - 7z e libsodium-1.0.2-mingw.tar.gz && 7z x libsodium-1.0.2-mingw.tar -olibsodium -y
+  - mkdir third_party_libs
+  - if "%RUST_INSTALL_TRIPLE%" == "i686-pc-windows-gnu" SET PATH=C:\MinGW\bin;%PATH% && copy libsodium\libsodium-win32\lib\libsodium.a third_party_libs\
+  - if "%RUST_INSTALL_TRIPLE%" == "x86_64-pc-windows-gnu" SET PATH=C:\mingw64\bin;%PATH% && copy libsodium\libsodium-win64\lib\libsodium.a third_party_libs\
 
 build: false
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-$Env:RUST_INSTALL_TRIPLE.exe"
   - cmd: rust-nightly-%RUST_INSTALL_TRIPLE%.exe /VERYSILENT /NORESTART /COMPONENTS="rust,gcc,cargo" /DIR="%RUST_INSTALL_DIR%"
-  - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin
+  - cmd: SET PATH=%PATH%;%RUST_INSTALL_DIR%\bin;
   - rustc --version
   - cargo --version
   - cinst 7zip.commandline -x86
@@ -24,10 +24,11 @@ install:
   - ps: Start-FileDownload 'https://download.libsodium.org/libsodium/releases/libsodium-1.0.2-mingw.tar.gz'
   - 7z e libsodium-1.0.2-mingw.tar.gz && 7z x libsodium-1.0.2-mingw.tar -olibsodium -y
   - mkdir third_party_libs
-  - if "%RUST_INSTALL_TRIPLE%" == "i686-pc-windows-gnu" SET PATH=C:\MinGW\bin;%PATH% && copy libsodium\libsodium-win32\lib\libsodium.a third_party_libs\
-  - if "%RUST_INSTALL_TRIPLE%" == "x86_64-pc-windows-gnu" SET PATH=C:\mingw64\bin;%PATH% && copy libsodium\libsodium-win64\lib\libsodium.a third_party_libs\
+  - if "%RUST_INSTALL_TRIPLE%" == "i686-pc-windows-gnu" copy libsodium\libsodium-win32\lib\libsodium.a third_party_libs\ && SET PATH=C:\MinGW\bin;%PATH%
+  - if "%RUST_INSTALL_TRIPLE%" == "x86_64-pc-windows-gnu" copy libsodium\libsodium-win64\lib\libsodium.a third_party_libs\ && SET PATH=C:\mingw64\bin;%PATH%
 
 build: false
+
 test_script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
Updated the appveyor config to build in x86 an x64 using mingw. Pointing the sodiumoxide dependency to use the fork.