### PR TITLE
Coverage integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success: |
   echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
   sudo pip install ghp-import &&
   ghp-import -n target/doc &&
-  git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages &&
+  git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
   sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev &&
   wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
   tar xzf master.tar.gz &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ after_success: |
   make &&
   sudo make install &&
   cd ../.. &&
-  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/routing-*
+  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/routing-*;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ install:
     - wget https://github.com/jedisct1/libsodium/releases/download/1.0.0/libsodium-1.0.0.tar.gz
     - tar xvfz libsodium-1.0.0.tar.gz
     - cd libsodium-1.0.0 && ./configure --prefix=/usr && make && sudo make install && cd ..
+    - wget https://www.sqlite.org/2015/sqlite-autoconf-3080803.tar.gz
+    - tar xvfz sqlite-autoconf-3080803.tar.gz
+    - cd sqlite-autoconf-3080803 && ./configure --prefix=/usr && make && sudo make install && cd ..
 script:
     - cargo build --verbose
     - cargo test --verbose
@@ -20,4 +23,14 @@ after_success: |
   echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
   sudo pip install ghp-import &&
   ghp-import -n target/doc &&
-  git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+  git push -f https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages &&
+  sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev &&
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+  tar xzf master.tar.gz &&
+  mkdir kcov-master/build &&
+  cd kcov-master/build &&
+  cmake .. &&;
+  make &&
+  sudo make install &&
+  cd ../.. &&
+  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/routing-*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "http://www.maidsafe.net"
 rustc-serialize = "*"
 cbor = "*"
 time = "*"
-#sodiumoxide= "*"
+sodiumoxide= "*"
 
 [dependencies.bchannel]
 git="https://github.com/dirvine/bchannel"
@@ -27,6 +27,3 @@ git="https://github.com/linuxfood/rustsqlite.git"
 
 [dependencies.maidsafe_types]
 git = "https://github.com/dirvine/maidsafe_types"
-
-[dependencies.sodiumoxide]
-git = "https://github.com/dnaq/sodiumoxide"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Extract and place the libsodium.a file in "bin\x86_64-pc-windows-gnu" for 64bit 
 SQLite3 is also native dependency for [rustsqlite](https://github.com/linuxfood/rustsqlite).
 Steps to compile SQLite by,
 1. Download SQLite Source code which includes a "configure" script from [SQLite download page](https://www.sqlite.org/download.html) 
-2. Run `./configure && make` to build the SQLite source. Windows Users can build using (mingw + msys)
-3. Copy the `libsqlite3.a` file from the .libs folder to the users/lib, windows users can place `libsqlite3.a` file in "bin\{TRIPLE}" in the project root folder.
+2. On Linux, Run `./configure --prefix=/usr && make && sudo make install` to build the SQLite source. While on Windows Users can build using (mingw + msys) and run './configure && make' 
+3. On Windows, Copy the `libsqlite3.a` file from the .libs folder to the "bin\{TARGET-TRIPLE}" in the project root folder.
  
  
 ##Todo Items


### PR DESCRIPTION
Must enable coveralls.io for routing repository for coverage results to be published in coveralls.io. README updated for SQLite. 