### PR TITLE
Remove nul redirect in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - rustc --version
   - ps: if($env:RUST_INSTALL_TRIPLE -eq 'x86_64-pc-windows-gnu') {
          Start-FileDownload "http://libgd.blob.core.windows.net/mingw/mingw-w64-dgn-x86_64-20141001.7z";
-          7z x -oC:\ mingw-w64-dgn-x86_64-20141001.7z > nul;
+          7z x -oC:\ mingw-w64-dgn-x86_64-20141001.7z;
           Start-FileDownload "https://gitlab.com/Fraser999/Dependencies/raw/master/bin/x86_64-pc-windows-gnu/libsodium.a";
           mkdir .\bin\x86_64-pc-windows-gnu;
           move libsodium.a .\bin\x86_64-pc-windows-gnu;


### PR DESCRIPTION
```
Redirection to 'nul' failed: FileStream will not open Win32 devices such as disk partitions and tape drives. Avoid use of "\\.\" in the path.
At line:1 char:156
+ ... -20141001.7z"; 7z x -oC:\ mingw-w64-dgn-x86_64-20141001.7z > nul; Start-FileDown ...
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : RedirectionFailed
```