### PR TITLE
Update merge logic of FindGroupResponse GetGroupKeyResponse

### DIFF
--- a/src/messages/find_group_response.rs
+++ b/src/messages/find_group_response.rs
@@ -40,7 +40,7 @@ impl FindGroupResponse {
         for response in responses {
             freq_target_id.update(response.target_id.clone());
         }
-        // first identify the target_ids; Select all that are mentioned more than QuorumSize.
+        // first identify the target_ids;
         let target_ids : Vec<NameType> = freq_target_id.sort_by_highest()
                                        .iter()
                                        .map(|&(ref id, _ )| id.clone())

--- a/src/messages/find_group_response.rs
+++ b/src/messages/find_group_response.rs
@@ -18,7 +18,7 @@
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::Frequency;
-use types::{PublicPmid, GROUP_SIZE};
+use types::{PublicPmid, GROUP_SIZE, QUORUM_SIZE};
 use NameType;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -32,29 +32,37 @@ impl FindGroupResponse {
     // TODO(ben 2015-04-09) to be replaced with a proper merge trait
     //                      for every message type
     pub fn merge(responses : &Vec<FindGroupResponse>) -> Option<FindGroupResponse> {
-        let mut frequency = Frequency::new();
-
         if responses.is_empty() {
             return None;
         }
 
+        let mut freq_target_id = Frequency::new();
         for response in responses {
-            for public_pmid in &response.group {
-                frequency.update(public_pmid.clone());
-            }
+            freq_target_id.update(response.target_id.clone());
         }
-
-        let frequency_count = frequency.sort_by_highest();
-
-        let merged_group = frequency.sort_by_highest().iter()
-                           .take(GROUP_SIZE as usize)
-                           .map(|&(ref k, _)| k.clone())
-                           .collect();
-
-        // FIXME: How should we merge the target_id?
-        let target_id = responses[0].target_id.clone();
-
-        Some(FindGroupResponse{target_id : target_id, group : merged_group})
+        // first identify the target_ids; Select all that are mentioned more than QuorumSize.
+        let target_ids : Vec<NameType> = freq_target_id.sort_by_highest()
+                                       .iter()
+                                       .filter(|pair| pair.1 >= QUORUM_SIZE as usize)
+                                       .map(|&(ref id, _ )| id.clone())
+                                       .collect();
+        for target_id in target_ids {
+            let mut freq_public_pmid = Frequency::new();
+            for response in responses.iter()
+                                     .filter(|response| &response.target_id == &target_id) {
+                for public_pmid in &response.group {
+                    freq_public_pmid.update(public_pmid.clone());
+                }
+            }
+            let merged_group : Vec<PublicPmid>
+                             = freq_public_pmid.sort_by_highest().iter()
+                                               .take(GROUP_SIZE as usize)
+                                               .map(|&(ref k, _)| k.clone())
+                                               .collect();
+            if merged_group.len() >= QUORUM_SIZE as usize {
+                return Some(FindGroupResponse{target_id : target_id, group : merged_group}); };
+        }
+        return None;
     }
 }
 

--- a/src/messages/find_group_response.rs
+++ b/src/messages/find_group_response.rs
@@ -18,7 +18,7 @@
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::Frequency;
-use types::{PublicPmid, GROUP_SIZE, QUORUM_SIZE};
+use types::{PublicPmid, GROUP_SIZE};
 use NameType;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -43,7 +43,6 @@ impl FindGroupResponse {
         // first identify the target_ids; Select all that are mentioned more than QuorumSize.
         let target_ids : Vec<NameType> = freq_target_id.sort_by_highest()
                                        .iter()
-                                       .filter(|pair| pair.1 >= QUORUM_SIZE as usize)
                                        .map(|&(ref id, _ )| id.clone())
                                        .collect();
         for target_id in target_ids {
@@ -59,7 +58,7 @@ impl FindGroupResponse {
                                                .take(GROUP_SIZE as usize)
                                                .map(|&(ref k, _)| k.clone())
                                                .collect();
-            if merged_group.len() >= QUORUM_SIZE as usize {
+            if !merged_group.is_empty() {
                 return Some(FindGroupResponse{target_id : target_id, group : merged_group}); };
         }
         return None;

--- a/src/messages/get_group_key_response.rs
+++ b/src/messages/get_group_key_response.rs
@@ -34,30 +34,37 @@ pub struct GetGroupKeyResponse {
 impl GetGroupKeyResponse {
 
     pub fn merge(get_group_key_responses: &Vec<GetGroupKeyResponse>) -> Option<GetGroupKeyResponse> {
-        type Key = (NameType, types::PublicSignKey);
-
         if get_group_key_responses.is_empty() {
             return None;
         }
 
-        let mut frequency = Frequency::new();
-
+        let mut freq_target_id = Frequency::new();
         for response in get_group_key_responses {
-          for public_sign_key in &response.public_sign_keys {
-              frequency.update(public_sign_key.clone());
-          }
+            freq_target_id.update(response.target_id.clone());
         }
-
-        let merged_group = frequency.sort_by_highest().iter()
-                           .take(types::GROUP_SIZE as usize)
-                           .map(|&(ref k, _)| k.clone())
-                           .collect();
-
-        // FIXME: How should we merge the target_id?
-        let target_id = get_group_key_responses[0].target_id.clone();
-
-        Some(GetGroupKeyResponse{target_id        : target_id,
-                                 public_sign_keys : merged_group})
+        // first identify the target_ids;
+        let target_ids : Vec<NameType> = freq_target_id.sort_by_highest()
+                                       .iter()
+                                       .map(|&(ref id, _ )| id.clone())
+                                       .collect();
+        for target_id in target_ids {
+            let mut freq_public_sign_key = Frequency::new();
+            for response in get_group_key_responses.iter()
+                              .filter(|response| &response.target_id == &target_id) {
+                for public_sign_key in &response.public_sign_keys {
+                    freq_public_sign_key.update(public_sign_key.clone());
+                }
+            }
+            let merged_group : Vec<(NameType, types::PublicSignKey)>
+                             = freq_public_sign_key.sort_by_highest().iter()
+                                                   .take(types::GROUP_SIZE as usize)
+                                                   .map(|&(ref k, _)| k.clone())
+                                                   .collect();
+            if !merged_group.is_empty() {
+                return Some(GetGroupKeyResponse{target_id : target_id,
+                                                public_sign_keys : merged_group}); };
+        }
+        return None;
     }
 }
 


### PR DESCRIPTION
includes previous pull request and extends the same logic of merging target_id also for GetGroupKeyResponse; after handling FindGroupResponse in previous PR

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/122)
<!-- Reviewable:end -->
