### PR TITLE
Exposing closer_to_target as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub mod types;
 use sodiumoxide::crypto;
 
 /// NameType is a 512bit name to address elements on the DHT network.
-pub use name_type::{NameType};
+pub use name_type::{NameType, closer_to_target};
 
 //#[derive(RustcEncodable, RustcDecodable)]
 struct SignedKey {


### PR DESCRIPTION
The logic can be used from other libraries. Since there will be a version update, I thought of pushing this along with the update.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/128)
<!-- Reviewable:end -->
