### PR TITLE
independent additional test on routing_table::our_close_group()

### DIFF
--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -1071,6 +1071,32 @@ mod test {
     }
 
     #[test]
+    fn our_close_group_assert_sorted() {
+        // independent double verification of our_close_group()
+        // this test verifies that the close group is returned sorted
+        let our_pmid_name = types::Pmid::new().get_name();
+        let mut routing_table : RoutingTable = RoutingTable::new(our_pmid_name.clone());
+
+        let mut count : usize = 0;
+        loop {
+            routing_table.add_node(NodeInfo::new(
+                                   types::PublicPmid::new(&types::Pmid::new()), true));
+            count += 1;
+            if routing_table.size() >=
+                RoutingTable::get_optimal_size() { break; }
+            if count >= 2 * RoutingTable::get_optimal_size() {
+                panic!("Routing table does not fill up."); }
+        }
+        let our_close_group : Vec<NodeInfo> = routing_table.our_close_group();
+        assert_eq!(our_close_group.len(), RoutingTable::get_group_size() );
+        let mut closer_name : NameType = our_pmid_name.clone();
+        for close_node in our_close_group {
+            assert!(closer_to_target(&closer_name, &close_node.id, &our_pmid_name));
+            closer_name = close_node.id.clone();
+        }
+    }
+
+    #[test]
     fn our_close_group_test() {
         let mut table_unit_test = RoutingTableUnitTest::new();
         assert!(table_unit_test.table.our_close_group().is_empty());
@@ -1086,16 +1112,9 @@ mod test {
         table_unit_test.complete_filling_table();
         assert_eq!(RoutingTable::get_group_size(), table_unit_test.table.our_close_group().len());
 
-        table_unit_test.table.our_close_group().sort_by(
-            |a, b| if closer_to_target(&a.id, &b.id, &table_unit_test.our_id) {
-                cmp::Ordering::Less
-            } else {
-                cmp::Ordering::Greater
-            });
-
         for close_node in table_unit_test.table.our_close_group().iter() {
             assert!(table_unit_test.added_ids.iter().filter(
-                |&node| { node == &close_node.id }).count() > 0);
+                |&node| { node == &close_node.id }).count() == 1);
         }
     }
 


### PR DESCRIPTION
this test verifies that the returned close group is sorted.
removed uneffective sort from existing our_close_group test

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/135)
<!-- Reviewable:end -->
