### PR TITLE
Removing stray RoutingTrait

### DIFF
--- a/src/name_type.rs
+++ b/src/name_type.rs
@@ -221,7 +221,6 @@ mod test {
     fn format_pmid_nametype() {
         // test for Pmids
         use types::Pmid;
-        use types::RoutingTrait;
         for _ in 0..5 {
             let my_pmid = Pmid::new();
             let my_name = my_pmid.get_name();

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -36,7 +36,7 @@ use node_interface::Interface;
 use routing_table::{RoutingTable, NodeInfo};
 use sendable::Sendable;
 use types;
-use types::{MessageId, RoutingTrait, Authority};
+use types::{MessageId, Authority};
 use message_header::MessageHeader;
 use messages;
 use messages::get_data::GetData;

--- a/src/routing_table.rs
+++ b/src/routing_table.rs
@@ -21,7 +21,7 @@ use sodiumoxide::crypto;
 use std::cmp;
 use std::usize;
 use NameType;
-use types::{PublicPmid, RoutingTrait};
+use types::PublicPmid;
 use name_type::closer_to_target;
 
 static BUCKET_SIZE: usize = 1;
@@ -50,7 +50,7 @@ impl NodeInfo {
   pub fn new(fob: PublicPmid, connected: bool)
          -> NodeInfo {
     NodeInfo {
-      id : fob.get_name(),
+      id : fob.name.clone(),
       fob : fob,
       connected : connected
     }
@@ -387,7 +387,7 @@ mod test {
     use std::cmp;
     use std::collections::BitVec;
     use std::net::*;
-    use types::{PublicPmid, RoutingTrait};
+    use types::PublicPmid;
     use name_type::closer_to_target;
     use types;
     use NameType;
@@ -557,7 +557,7 @@ mod test {
     fn create_random_node_info() -> NodeInfo {
         let public_pmid = types::PublicPmid::new(&types::Pmid::new());
         NodeInfo {
-            id : public_pmid.get_name(),
+            id : public_pmid.name.clone(),
             fob: public_pmid,
             connected: false,
         }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -314,7 +314,6 @@ mod test {
   use std::cmp;
   use sodiumoxide::crypto;
   use types;
-  use types::RoutingTrait;
   use name_type::closer_to_target;
   use NameType;
   use message_header;

--- a/src/types.rs
+++ b/src/types.rs
@@ -363,12 +363,6 @@ impl Decodable for AccountTransferInfo {
   }
 }
 
-impl RoutingTrait for AccountTransferInfo {
-    fn get_name(&self)->NameType { self.name.clone() }
-    fn get_owner(&self)->Vec<u8> { Vec::<u8>::new() } // TODO owner
-    fn refresh(&self)->bool { true } // TODO is this an account transfer type
-}
-
 /// Address of the source of the message
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct SourceAddress {

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,11 +112,11 @@ pub type SerialisedMessage = Vec<u8>;
 pub type PmidNode = NameType;
 pub type PmidNodes = Vec<PmidNode>;
 
-pub trait RoutingTrait {
-  fn get_name(&self)->NameType;
-  fn get_owner(&self)->Vec<u8>;
-  fn refresh(&self)->bool;
-}
+// pub trait RoutingTrait {
+//   fn get_name(&self)->NameType;
+//   fn get_owner(&self)->Vec<u8>;
+//   fn refresh(&self)->bool;
+// }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct NameAndTypeId {
@@ -259,13 +259,6 @@ impl PublicPmid {
         name : pmid.get_name()
       }
     }
-
-}
-
-impl RoutingTrait for PublicPmid {
-  fn get_name(&self) -> NameType { self.name.clone() }
-  fn get_owner(&self)->Vec<u8> { Vec::<u8>::new() } // TODO owner
-  fn refresh(&self)->bool { false } // TODO is this an account transfer type
 }
 
 impl Encodable for PublicPmid {
@@ -297,12 +290,6 @@ pub struct Pmid {
   name: NameType
 }
 
-impl RoutingTrait for Pmid {
-  fn get_name(&self) -> NameType { self.name.clone() }
-  fn get_owner(&self)->Vec<u8> { Vec::<u8>::new() } // TODO owner
-  fn refresh(&self)->bool { false } // TODO is this an account transfer type
-}
-
 impl Pmid {
   pub fn new() -> Pmid {
     let (pub_sign_key, sec_sign_key) = sodiumoxide::crypto::sign::gen_keypair();
@@ -331,7 +318,9 @@ impl Pmid {
       name : NameType::new(digest.0)
     }
   }
-
+  pub fn get_name(&self) -> NameType {
+    self.name.clone()
+  }
   pub fn get_public_key(&self) -> PublicKey {
     PublicKey::new(self.public_keys.1.clone())
   }

--- a/src/types.rs
+++ b/src/types.rs
@@ -112,12 +112,6 @@ pub type SerialisedMessage = Vec<u8>;
 pub type PmidNode = NameType;
 pub type PmidNodes = Vec<PmidNode>;
 
-// pub trait RoutingTrait {
-//   fn get_name(&self)->NameType;
-//   fn get_owner(&self)->Vec<u8>;
-//   fn refresh(&self)->bool;
-// }
-
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub struct NameAndTypeId {
   pub name : NameType,


### PR DESCRIPTION
Removing stray RoutingTrait. It is now replaced by Sendable.
Also it was used for Pmid keys, which is not desirable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/140)
<!-- Reviewable:end -->
