### PR TITLE
Signature checks and more correct `merge` (exploits faults in tests!)

### DIFF
--- a/src/messages/find_group_response.rs
+++ b/src/messages/find_group_response.rs
@@ -21,7 +21,7 @@
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::Frequency;
-use types::{PublicPmid, GROUP_SIZE};
+use types::{PublicPmid, GROUP_SIZE, QUORUM_SIZE};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct FindGroupResponse {
@@ -43,9 +43,10 @@ impl FindGroupResponse {
             }
         }
 
-        let merged_group = frequency.sort_by_highest().iter()
+        let merged_group = frequency.sort_by_highest().into_iter()
+                           .filter(|&(_, ref count)| *count >= QUORUM_SIZE as usize)
                            .take(GROUP_SIZE as usize)
-                           .map(|&(ref k, _)| k.clone())
+                           .map(|(k, _)| k)
                            .collect();
 
         Some(FindGroupResponse{ group: merged_group })

--- a/src/messages/find_group_response.rs
+++ b/src/messages/find_group_response.rs
@@ -21,20 +21,15 @@
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::Frequency;
-use types::{PublicPmid, GROUP_SIZE, QUORUM_SIZE};
+use types::{PublicPmid, GROUP_SIZE, QUORUM_SIZE, Mergable};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct FindGroupResponse {
   pub group : Vec<PublicPmid>
 }
 
-impl FindGroupResponse {
-
-    pub fn merge(responses: &Vec<FindGroupResponse>) -> Option<FindGroupResponse> {
-        if responses.is_empty() {
-            return None;
-        }
-
+impl Mergable for FindGroupResponse {
+    fn merge<'a, I>(responses: I) -> Option<Self> where I: Iterator<Item=&'a Self> {
         let mut frequency = Frequency::new();
 
         for response in responses {
@@ -47,8 +42,9 @@ impl FindGroupResponse {
                            .filter(|&(_, ref count)| *count >= QUORUM_SIZE as usize)
                            .take(GROUP_SIZE as usize)
                            .map(|(k, _)| k)
-                           .collect();
+                           .collect::<Vec<_>>();
 
+        if merged_group.is_empty() { return None; }
         Some(FindGroupResponse{ group: merged_group })
     }
 }
@@ -118,7 +114,7 @@ mod test {
             responses.push(response);
         }
 
-        let merged_obj = FindGroupResponse::merge(&responses);
+        let merged_obj = types::Mergable::merge(responses.iter());
         assert!(merged_obj.is_some());
         let merged_response = merged_obj.unwrap();
         for i in 0..7 {

--- a/src/messages/get_group_key_response.rs
+++ b/src/messages/get_group_key_response.rs
@@ -21,8 +21,7 @@
 use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::{Frequency};
-
-use types::{PublicSignKey, GROUP_SIZE, QUORUM_SIZE};
+use types::{PublicSignKey, GROUP_SIZE, QUORUM_SIZE, Mergable};
 use NameType;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
@@ -30,16 +29,11 @@ pub struct GetGroupKeyResponse {
   pub public_sign_keys : Vec<(NameType, PublicSignKey)>
 }
 
-impl GetGroupKeyResponse {
-
-    pub fn merge(get_group_key_responses: &Vec<GetGroupKeyResponse>) -> Option<GetGroupKeyResponse> {
-        if get_group_key_responses.is_empty() {
-            return None;
-        }
-
+impl Mergable for GetGroupKeyResponse {
+    fn merge<'a, I>(xs: I) -> Option<Self> where I: Iterator<Item=&'a Self> {
         let mut frequency = Frequency::new();
 
-        for response in get_group_key_responses {
+        for response in xs {
             for public_sign_key in &response.public_sign_keys {
                 frequency.update(public_sign_key.clone());
             }
@@ -49,8 +43,9 @@ impl GetGroupKeyResponse {
                            .filter(|&(_, ref count)| *count >= QUORUM_SIZE as usize)
                            .take(GROUP_SIZE as usize)
                            .map(|(k, _)| k)
-                           .collect();
+                           .collect::<Vec<_>>();
 
+        if merged_group.is_empty() { return None; }
         Some(GetGroupKeyResponse{ public_sign_keys: merged_group })
     }
 }
@@ -121,7 +116,7 @@ mod test {
             responses.push(response);
         }
 
-        let merged_obj = GetGroupKeyResponse::merge(&responses);
+        let merged_obj = types::Mergable::merge(responses.iter());
         assert!(merged_obj.is_some());
         let merged_response = merged_obj.unwrap();
         for i in 0..7 {

--- a/src/messages/get_group_key_response.rs
+++ b/src/messages/get_group_key_response.rs
@@ -22,7 +22,7 @@ use cbor::CborTagEncode;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use frequency::{Frequency};
 
-use types::{PublicSignKey, GROUP_SIZE};
+use types::{PublicSignKey, GROUP_SIZE, QUORUM_SIZE};
 use NameType;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
@@ -45,9 +45,10 @@ impl GetGroupKeyResponse {
             }
         }
 
-        let merged_group = frequency.sort_by_highest().iter()
+        let merged_group = frequency.sort_by_highest().into_iter()
+                           .filter(|&(_, ref count)| *count >= QUORUM_SIZE as usize)
                            .take(GROUP_SIZE as usize)
-                           .map(|&(ref k, _)| k.clone())
+                           .map(|(k, _)| k)
                            .collect();
 
         Some(GetGroupKeyResponse{ public_sign_keys: merged_group })

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -154,18 +154,6 @@ impl<'a> Sentinel<'a> {
       None
     }
 
-    fn update_key_map(key_map: &mut HashMap<NameType, Vec<PublicSignKey>>, addr: NameType, key: PublicSignKey) {
-        if !key_map.contains_key(&addr) {
-            key_map.insert(addr, vec![key]);
-        }
-        else {
-            let mut public_keys = key_map.get_mut(&addr).unwrap();
-            if !public_keys.contains(&key) {
-                public_keys.push(key);
-            }
-        }
-    }
-
     fn check_signature(response: &ResultType, pub_key: &PublicSignKey) -> Option<ResultType> {
         response.0.get_signature().and_then(|signature| {
           let is_correct = crypto::sign::verify_detached(
@@ -750,7 +738,7 @@ mod test {
     let embedded_signature_group = EmbeddedSignatureGroup::new(types::GROUP_SIZE as usize,
                types::Authority::NaeManager);
     let mut trace_get_keys = TraceGetKeys::new();
-    let mut sentinel_returns : Vec<(u64, Option<ResultType>)> = Vec::new();
+    let mut sentinel_returns = Vec::<(u64, Option<ResultType>)>::new();
     let mut message_tracker : u64 = 0;
     {
       let mut sentinel = Sentinel::new(&mut trace_get_keys);

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -76,8 +76,7 @@ impl<'a> Sentinel<'a> {
         MessageTypeTag::GetClientKeyResponse => {
           if header.is_from_group() {
             let keys = self.node_key_accumulator_.add(header.from_group().unwrap(),
-                                                      (header.clone(), type_tag, message),
-                                                      header.from_node());
+                                                      (header.clone(), type_tag, message));
             if keys.is_some() {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.node_accumulator_.get(key.clone());
@@ -95,8 +94,7 @@ impl<'a> Sentinel<'a> {
         MessageTypeTag::GetGroupKeyResponse => {
           if header.is_from_group() {
             let keys = self.group_key_accumulator_.add(header.from_group().unwrap(),
-                                                       (header.clone(), type_tag, message),
-                                                       header.from_node());
+                                                       (header.clone(), type_tag, message));
             if keys.is_some() {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.group_accumulator_.get(key.clone());
@@ -117,8 +115,7 @@ impl<'a> Sentinel<'a> {
             if !self.group_accumulator_.have_name(key.clone()) {
               self.send_get_keys_.get_group_key(header.from_group().unwrap()); };
             let messages = self.group_accumulator_.add(key.clone(),
-                                                       (header.clone(), type_tag, message),
-                                                       header.from_node());
+                                                       (header.clone(), type_tag, message));
             if messages.is_some() {
               let keys = self.group_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
@@ -135,8 +132,7 @@ impl<'a> Sentinel<'a> {
             if !self.node_accumulator_.have_name(key.clone()) {
               self.send_get_keys_.get_client_key(header.from_group().unwrap()); };
             let messages = self.node_accumulator_.add(key.clone(),
-                                                      (header.clone(), type_tag, message),
-                                                      header.from_node());
+                                                      (header.clone(), type_tag, message));
             if messages.is_some() {
               let keys = self.node_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
@@ -270,10 +266,6 @@ impl<'a> Sentinel<'a> {
                 .map(|merged| { (header, tag, merged) })
         }
     }
-}
-
-fn has_single_entry<T>(key_map: &HashMap<NameType, Vec<T>>) -> bool {
-    key_map.len() == 1 && key_map.iter().next().unwrap().1.len() == 1
 }
 
 fn take_most_frequent<E>(elements: &Vec<E>, min_count: usize) -> Option<E>

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -82,8 +82,8 @@ impl<'a> Sentinel<'a> {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.node_accumulator_.get(key.clone());
               if messages.is_some() {
-                let resolved = self.resolve(self.validate_node(messages.unwrap().1,
-                                                               keys.unwrap().1), false);
+                let resolved = self.resolve(Sentinel::validate_node(messages.unwrap().1,
+                                                                    keys.unwrap().1), false);
                 if resolved.is_some() {
                   self.node_accumulator_.delete(key);
                   return resolved;
@@ -101,8 +101,8 @@ impl<'a> Sentinel<'a> {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.group_accumulator_.get(key.clone());
               if messages.is_some() {
-                let resolved = self.resolve(self.validate_group(messages.unwrap().1,
-                                                                keys.unwrap().1), true);
+                let resolved = self.resolve(Sentinel::validate_group(messages.unwrap().1,
+                                                                     keys.unwrap().1), true);
                 if resolved.is_some() {
                   self.group_accumulator_.delete(key);
                   return resolved;
@@ -122,8 +122,8 @@ impl<'a> Sentinel<'a> {
             if messages.is_some() {
               let keys = self.group_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
-                let resolved = self.resolve(self.validate_group(messages.unwrap().1,
-                                                                keys.unwrap().1), true);
+                let resolved = self.resolve(Sentinel::validate_group(messages.unwrap().1,
+                                                                     keys.unwrap().1), true);
                 if resolved.is_some() {
                   self.group_accumulator_.delete(key);
                   return resolved;
@@ -140,8 +140,8 @@ impl<'a> Sentinel<'a> {
             if messages.is_some() {
               let keys = self.node_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
-                let resolved = self.resolve(self.validate_node(messages.unwrap().1,
-                                                               keys.unwrap().1), false);
+                let resolved = self.resolve(Sentinel::validate_node(messages.unwrap().1,
+                                                                    keys.unwrap().1), false);
                 if resolved.is_some() {
                   self.node_accumulator_.delete(key);
                   return resolved;
@@ -178,8 +178,7 @@ impl<'a> Sentinel<'a> {
         })
     }
 
-    fn validate_node(&self,
-                     messages: Vec<accumulator::Response<ResultType>>,
+    fn validate_node(messages: Vec<accumulator::Response<ResultType>>,
                      keys:     Vec<accumulator::Response<ResultType>>) -> Vec<ResultType> {
         if messages.len() == 0 || keys.len() < types::QUORUM_SIZE as usize {
           return Vec::new();
@@ -204,8 +203,7 @@ impl<'a> Sentinel<'a> {
             .collect::<Vec<_>>()
     }
 
-    fn validate_group(&self,
-                      messages: Vec<accumulator::Response<ResultType>>,
+    fn validate_group(messages: Vec<accumulator::Response<ResultType>>,
                       keys:     Vec<accumulator::Response<ResultType>>) -> Vec<ResultType> {
         if messages.len() < types::QUORUM_SIZE as usize || keys.len() < types::QUORUM_SIZE as usize {
             return Vec::<ResultType>::new();

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -162,15 +162,15 @@ impl<'a> Sentinel<'a> {
         })
     }
 
-    fn validate_node(messages: Vec<accumulator::Response<ResultType>>,
-                     keys:     Vec<accumulator::Response<ResultType>>) -> Vec<ResultType> {
+    fn validate_node(messages: Vec<ResultType>,
+                     keys:     Vec<ResultType>) -> Vec<ResultType> {
         if messages.len() == 0 || keys.len() < types::QUORUM_SIZE as usize {
           return Vec::new();
         }
 
         // TODO: Would be nice if we didn't need to decode it here every time
         // this function is called. We could then avoid the below check as well.
-        let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.value.2)).collect::<Vec<_>>();
+        let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.2)).collect::<Vec<_>>();
 
         // Need to check this again because decoding may have failed.
         if keys.len() < types::QUORUM_SIZE as usize {
@@ -181,21 +181,21 @@ impl<'a> Sentinel<'a> {
             .into_iter()
             .flat_map(|GetClientKeyResponse{address: _, public_sign_key: pub_key}| {
                 messages.iter().filter_map(move |response| {
-                    Sentinel::check_signature(&response.value, &pub_key)
+                    Sentinel::check_signature(&response, &pub_key)
                 })
             })
             .collect::<Vec<_>>()
     }
 
-    fn validate_group(messages: Vec<accumulator::Response<ResultType>>,
-                      keys:     Vec<accumulator::Response<ResultType>>) -> Vec<ResultType> {
+    fn validate_group(messages: Vec<ResultType>,
+                      keys:     Vec<ResultType>) -> Vec<ResultType> {
         if messages.len() < types::QUORUM_SIZE as usize || keys.len() < types::QUORUM_SIZE as usize {
             return Vec::<ResultType>::new();
         }
 
         // TODO: Would be nice if we didn't need to decode it here every time
         // this function is called. We could then avoid the below check as well.
-        let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.value.2)).collect::<Vec<_>>();
+        let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.2)).collect::<Vec<_>>();
 
         // Need to check this again because decoding may have failed.
         if keys.len() < types::QUORUM_SIZE as usize {
@@ -210,8 +210,8 @@ impl<'a> Sentinel<'a> {
             .collect::<HashMap<_,_>>();
 
         messages.iter().filter_map(|message| {
-            key_map.get(&message.value.0.from_node())
-                .and_then(|pub_key| Sentinel::check_signature(&message.value, &pub_key))
+            key_map.get(&message.0.from_node())
+                .and_then(|pub_key| Sentinel::check_signature(&message, &pub_key))
         })
         .collect::<Vec<_>>()
     }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -81,8 +81,8 @@ impl<'a> Sentinel<'a> {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.node_accumulator_.get(key.clone());
               if messages.is_some() {
-                let resolved = self.resolve(Sentinel::validate_node(messages.unwrap().1,
-                                                                    keys.unwrap().1), false);
+                let resolved = Sentinel::resolve(Sentinel::validate_node(messages.unwrap().1,
+                                                                         keys.unwrap().1));
                 if resolved.is_some() {
                   self.node_accumulator_.delete(key);
                   return resolved;
@@ -99,8 +99,8 @@ impl<'a> Sentinel<'a> {
               let key = (header.from_group().unwrap(), header.message_id());
               let messages = self.group_accumulator_.get(key.clone());
               if messages.is_some() {
-                let resolved = self.resolve(Sentinel::validate_group(messages.unwrap().1,
-                                                                     keys.unwrap().1), true);
+                let resolved = Sentinel::resolve(Sentinel::validate_group(messages.unwrap().1,
+                                                                          keys.unwrap().1));
                 if resolved.is_some() {
                   self.group_accumulator_.delete(key);
                   return resolved;
@@ -119,8 +119,8 @@ impl<'a> Sentinel<'a> {
             if messages.is_some() {
               let keys = self.group_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
-                let resolved = self.resolve(Sentinel::validate_group(messages.unwrap().1,
-                                                                     keys.unwrap().1), true);
+                let resolved = Sentinel::resolve(Sentinel::validate_group(messages.unwrap().1,
+                                                                          keys.unwrap().1));
                 if resolved.is_some() {
                   self.group_accumulator_.delete(key);
                   return resolved;
@@ -136,8 +136,8 @@ impl<'a> Sentinel<'a> {
             if messages.is_some() {
               let keys = self.node_key_accumulator_.get(header.from_group().unwrap());
               if keys.is_some() {
-                let resolved = self.resolve(Sentinel::validate_node(messages.unwrap().1,
-                                                                    keys.unwrap().1), false);
+                let resolved = Sentinel::resolve(Sentinel::validate_node(messages.unwrap().1,
+                                                                         keys.unwrap().1));
                 if resolved.is_some() {
                   self.node_accumulator_.delete(key);
                   return resolved;
@@ -227,7 +227,7 @@ impl<'a> Sentinel<'a> {
         e.as_bytes().to_vec()
     }
 
-    fn resolve(&self, verified_messages : Vec<ResultType>, _ : bool) -> Option<ResultType> {
+    fn resolve(verified_messages : Vec<ResultType>) -> Option<ResultType> {
         if verified_messages.len() < QUORUM_SIZE as usize {
             return None;
         }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -259,15 +259,15 @@ impl<'a> Sentinel<'a> {
                  Sentinel::encode(merged))
             })
         } else {
-            let msg_bodies = verified_messages.iter()
-                             .map(|&(_, _, ref body)| body.clone())
+            let header = verified_messages[0].0.clone();
+            let tag    = verified_messages[0].1.clone();
+
+            let msg_bodies = verified_messages.into_iter()
+                             .map(|(_, _, body)| body)
                              .collect::<Vec<_>>();
 
-            take_most_frequent(&msg_bodies, types::QUORUM_SIZE as usize).map(|merged| {
-                (verified_messages[0].0.clone(),
-                 verified_messages[0].1.clone(),
-                 merged)
-            })
+            take_most_frequent(&msg_bodies, types::QUORUM_SIZE as usize)
+                .map(|merged| { (header, tag, merged) })
         }
     }
 }
@@ -282,8 +282,8 @@ where E: Clone + Ord {
     for element in elements {
         freq_counter.update(element.clone());
     }
-    freq_counter.sort_by_highest().iter().nth(0).and_then(|&(ref element,ref count)| {
-        if *count >= min_count as usize { Some(element.clone()) } else { None }
+    freq_counter.sort_by_highest().into_iter().nth(0).and_then(|(element, count)| {
+        if count >= min_count as usize { Some(element) } else { None }
     })
 }
 

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -24,6 +24,7 @@ use accumulator;
 use message_header;
 use NameType;
 use types;
+use types::{Mergable};
 use frequency::Frequency;
 use messages::find_group_response::FindGroupResponse;
 use messages::get_client_key_response::GetClientKeyResponse;
@@ -219,7 +220,7 @@ impl<'a> Sentinel<'a> {
             return Vec::<ResultType>::new();
         }
 
-        let key_map = GetGroupKeyResponse::merge(&keys)
+        let key_map = Mergable::merge(keys.iter())
             .into_iter()
             .flat_map(|GetGroupKeyResponse{public_sign_keys: addr_key_pairs}| {
                 addr_key_pairs.into_iter()
@@ -256,7 +257,7 @@ impl<'a> Sentinel<'a> {
                 .filter_map(|msg| Sentinel::decode::<FindGroupResponse>(&msg.2))
                 .collect::<Vec<_>>();
 
-            FindGroupResponse::merge(&decoded_responses).map(|merged| {
+            Mergable::merge(decoded_responses.iter()).map(|merged| {
                 (verified_messages[0].0.clone(),
                  verified_messages[0].1.clone(),
                  Sentinel::encode(merged))
@@ -266,7 +267,7 @@ impl<'a> Sentinel<'a> {
                 .filter_map(|msg_triple| { Sentinel::decode::<GetGroupKeyResponse>(&msg_triple.2) })
                 .collect::<Vec<_>>();
 
-            GetGroupKeyResponse::merge(&accounts).map(|merged| {
+            Mergable::merge(accounts.iter()).map(|merged| {
                 (verified_messages[0].0.clone(),
                  verified_messages[0].1.clone(),
                  Sentinel::encode(merged))

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -188,6 +188,7 @@ impl<'a> Sentinel<'a> {
         // this function is called. We could then avoid the below check as well.
         let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.value.2)).collect::<Vec<_>>();
 
+        // Need to check this again because decoding may have failed.
         if keys.len() < types::QUORUM_SIZE as usize {
           return Vec::new();
         }
@@ -213,6 +214,7 @@ impl<'a> Sentinel<'a> {
         // this function is called. We could then avoid the below check as well.
         let keys = keys.iter().filter_map(|key_msg| Sentinel::decode(&key_msg.value.2)).collect::<Vec<_>>();
 
+        // Need to check this again because decoding may have failed.
         if keys.len() < types::QUORUM_SIZE as usize {
             return Vec::<ResultType>::new();
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,6 +61,10 @@ pub fn generate_random_vec_u8(size: usize) -> Vec<u8> {
 pub static GROUP_SIZE: u32 = 23;
 pub static QUORUM_SIZE: u32 = 19;
 
+pub trait Mergable {
+    fn merge<'a, I>(xs: I) -> Option<Self> where I: Iterator<Item=&'a Self>;
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum Authority {
   ClientManager,  // from a node in our range but not routing table

--- a/src/types.rs
+++ b/src/types.rs
@@ -196,7 +196,7 @@ impl PublicSignKey {
 
 impl fmt::Debug for PublicSignKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PublicSignKey(...)")
+        write!(f, "PublicSignKey({:?})", self.public_sign_key.iter().take(6).collect::<Vec<_>>())
     }
 }
 


### PR DESCRIPTION
Fixes merge logic for FindGroupResponse and GetGroupKeyResponse messages. Unfortunately these changes break tests in the corresponding message .rs files and sentinel.rs. I believe the fix needs to be done in the tests.

The main changes that cause the test failures are these two lines ([L42](https://github.com/inetic/routing/blob/master/src/messages/find_group_response.rs#L42), [L43](https://github.com/inetic/routing/blob/master/src/messages/find_group_response.rs#L43)) for FindGroupResponse and these two lines ([L43](https://github.com/inetic/routing/blob/master/src/messages/get_group_key_response.rs#L43), [L44](https://github.com/inetic/routing/blob/master/src/messages/get_group_key_response.rs#L44)) for GetGroupKeyResponse. Commenting out these lines makes the tests pass again as before.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/146)
<!-- Reviewable:end -->
