### PR TITLE
Message header sendon reply

### DIFF
--- a/src/message_header.rs
+++ b/src/message_header.rs
@@ -118,6 +118,24 @@ impl MessageHeader {
     pub fn from_authority(&self) -> types::Authority {
         self.authority.clone()
     }
+
+    /// Only a node in a manager will send_on a routing message;
+    /// after this message is processed by the interface.
+    /// Note: this is not for XOR-forwarding; then the header is preserved!
+    pub fn create_send_on(&self, our_name : &NameType, our_authority : &types::Authority,
+                          destination : &NameType) -> MessageHeader {
+        let mut send_on_header = self.clone();
+        send_on_header.source = types::SourceAddress {
+            from_node : our_name,
+            from_group : self.destination.dest.clone(),
+            reply_to : self.source.reply_to.clone()
+        }
+        send_on_header.destination = types::DestinationAddress {
+            dest : destination.clone(),
+            reply_to : self.destination.reply_to.clone()
+        }
+        send_on_header
+    }
 }
 
 #[cfg(test)]

--- a/src/message_header.rs
+++ b/src/message_header.rs
@@ -119,22 +119,48 @@ impl MessageHeader {
         self.authority.clone()
     }
 
-    /// Only a node in a manager will send_on a routing message;
-    /// after this message is processed by the interface.
+    /// This creates a new header for Action::SendOn. It clones all the fields,
+    /// and then mutates the destination and source accordingly.
+    /// Authority is changed at this point as this method is called after
+    /// the interface has processed the message.
     /// Note: this is not for XOR-forwarding; then the header is preserved!
     pub fn create_send_on(&self, our_name : &NameType, our_authority : &types::Authority,
                           destination : &NameType) -> MessageHeader {
+        // implicitly preserve all non-mutated fields.
         let mut send_on_header = self.clone();
         send_on_header.source = types::SourceAddress {
-            from_node : our_name,
+            from_node : our_name.clone(),
             from_group : self.destination.dest.clone(),
             reply_to : self.source.reply_to.clone()
-        }
+        };
         send_on_header.destination = types::DestinationAddress {
             dest : destination.clone(),
             reply_to : self.destination.reply_to.clone()
-        }
+        };
+        send_on_header.authority = our_authority.clone();
         send_on_header
+    }
+
+    /// This creates a new header for Action::Reply. It clones all the fields,
+    /// and then mutates the destination and source accordingly.
+    /// Authority is changed at this point as this method is called after
+    /// the interface has processed the message.
+    /// Note: this is not for XOR-forwarding; then the header is preserved!
+    pub fn create_reply(&self, our_name : &NameType, our_authority : &types::Authority)
+                        -> MessageHeader {
+        // implicitly preserve all non-mutated fields.
+        let reply_header = self.clone();
+        reply_header.source = types::SourceAddress {
+            from_node : our_name.clone(),
+            from_group : self.destination.dest.clone(),
+            reply_to : self.source.reply_to.clone()
+        };
+        reply_header.destination = types::DestinationAddress {
+            dest : self.source.from().clone(),
+            reply_to : self.destination.reply_to.clone()
+        };
+        reply_header.authority = our_authority.clone();
+        reply_header
     }
 }
 

--- a/src/message_header.rs
+++ b/src/message_header.rs
@@ -153,11 +153,11 @@ impl MessageHeader {
         reply_header.source = types::SourceAddress {
             from_node : our_name.clone(),
             from_group : self.destination.dest.clone(),
-            reply_to : self.source.reply_to.clone()
+            reply_to : None
         };
         reply_header.destination = types::DestinationAddress {
             dest : self.source.from().clone(),
-            reply_to : self.destination.reply_to.clone()
+            reply_to : self.source.reply_to.clone()
         };
         reply_header.authority = our_authority.clone();
         reply_header


### PR DESCRIPTION
Create a single place to mutate headers on Action::SendOn or Action::Reply; this gets called by a managed node after the interface has returned an Action to routing

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/164)
<!-- Reviewable:end -->
