### PR TITLE
Sendable trait changes - refresh & merge

### DIFF
--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -82,6 +82,14 @@ impl Sendable for TestData {
     fn type_tag(&self)->u64 { unimplemented!() }
 
     fn serialised_contents(&self)->Vec<u8> { self.data.clone() }
+
+    fn refresh(&self)->bool {
+        false
+    }
+
+    fn merge<'a, I>(responses: I) -> Option<Self> where I: Iterator<Item=&'a Self> {
+        None
+    }
 }
 
 impl PartialEq for TestData {

--- a/examples/routing.rs
+++ b/examples/routing.rs
@@ -107,8 +107,9 @@ struct TestNode {
 }
 
 impl Interface for TestNode {
-    fn handle_get(&mut self, type_id: u64, name : NameType, our_authority: types::Authority,
-                  from_authority: types::Authority, from_address: NameType) -> Result<Action, RoutingError> {
+    fn handle_get(&mut self, type_id: u64, name: NameType, our_authority: types::Authority,
+                  from_authority: types::Authority, from_address: NameType)
+                   -> Result<Action, RoutingError> {
         let stats = self.stats.clone();
         let mut stats_value = stats.lock().unwrap();
         for data in stats_value.stats.iter().filter(|data| data.1.name() == name) {
@@ -133,8 +134,8 @@ impl Interface for TestNode {
                    from_address: NameType, data: Vec<u8>) -> Result<Action, RoutingError> {
         Err(RoutingError::Success)
     }
-    fn handle_get_response(&mut self, from_address: NameType, response: Result<Vec<u8>,
-                           RoutingError>) {
+    fn handle_get_response(&mut self, from_address: NameType, 
+                        response: Result<Vec<u8>, RoutingError>) -> RoutingNodeAction {
         unimplemented!();
     }
     fn handle_put_response(&mut self, from_authority: types::Authority, from_address: NameType,
@@ -146,7 +147,7 @@ impl Interface for TestNode {
         unimplemented!();
     }
     fn handle_churn(&mut self, close_group: Vec<NameType>)
-        -> Vec<generic_sendable_type::GenericSendableType> {
+        -> Vec<RoutingNodeAction> {
         unimplemented!();
     }
     fn handle_cache_get(&mut self, type_id: u64, name : NameType, from_authority: types::Authority,
@@ -156,6 +157,10 @@ impl Interface for TestNode {
     fn handle_cache_put(&mut self, from_authority: types::Authority, from_address: NameType,
                         data: Vec<u8>) -> Result<Action, RoutingError> {
         Err(RoutingError::Success)
+    }
+    fn handle_get_key(&mut self, type_id: u64, name: NameType, our_authority: types::Authority,
+                      from_authority: types::Authority, from_address: NameType) -> Result<Action, RoutingError> {
+                      unimplemented!()
     }
 }
 

--- a/src/generic_sendable_type.rs
+++ b/src/generic_sendable_type.rs
@@ -47,4 +47,12 @@ impl Sendable for GenericSendableType {
     fn serialised_contents(&self) -> Vec<u8> {
         self.serialised_contents.clone()
     }
+
+    fn refresh(&self)->bool {
+        false
+    }
+
+    fn merge<'a, I>(responses: I) -> Option<Self> where I: Iterator<Item=&'a Self> {
+        None
+    }
 }

--- a/src/routing_node.rs
+++ b/src/routing_node.rs
@@ -930,6 +930,14 @@ mod test {
         fn type_tag(&self)->u64 { unimplemented!() }
 
         fn serialised_contents(&self)->Vec<u8> { self.data.clone() }
+
+        fn refresh(&self)->bool {
+            false
+        }
+
+        fn merge<'a, I>(responses: I) -> Option<Self> where I: Iterator<Item=&'a Self> {
+            None
+        }
     }
 
     impl Interface for TestInterface {

--- a/src/sendable.rs
+++ b/src/sendable.rs
@@ -26,8 +26,6 @@ pub trait Sendable {
     fn type_tag(&self)->u64;
     fn serialised_contents(&self)->Vec<u8>;
     fn owner(&self)->Option<name_type::NameType> { Option::None }
-    fn refresh(&self)->bool { false } // is this an account transfer type
-    fn merge<'a, I, T>(responses: I) -> Option<T> where I: Iterator<Item=&'a T>, T: Sendable {
-    	Option::None
-    } // how do we merge these
+    fn refresh(&self)->bool; // is this an account transfer type
+    fn merge<'a, I>(responses: I) -> Option<Self> where I: Iterator<Item=&'a Self>;
 }


### PR DESCRIPTION
Sendable trait refresh and merge fn updated. In example/routing.rs the trait had mismatch, thus resolved to get the test running

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/routing/170)
<!-- Reviewable:end -->
